### PR TITLE
Declare immutability-helper as direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "classnames": "~2.2.5",
     "core-js": "~2.4.0",
+    "immutability-helper": "^2.0.0",
     "normalize.css": "~4.2.0",
     "react-css-themr": "~1.4.1"
   },
@@ -114,8 +115,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "classnames": "~2.2.0",
-    "immutability-helper": "~2.0.0",
     "react": "~0.14 || ~15.3.0",
     "react-addons-css-transition-group": "~0.14.0 || ~15.3.0",
     "react-dom": "~0.14.0 || ~15.3.0"


### PR DESCRIPTION
As a library user, I should not care about some library implementation details, e.g. that it uses `immutability-helper`.

As well as `classnames`, which is already defined in dependencies, all other libraries, except` react-*` should be also installed automatically, when you are running `npm i react-toolbox`